### PR TITLE
Added parser for ugly and/or negative hex, fixed Serpent types

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,39 @@ For the same data structure:
 
 Note that ```ripemd160()``` in Solidity returns bytes20 and if you cast it to bytes32, it will be right padded with zeroes.
 
+#### Using Serpent types
+
+Serpent uses a different notation for the types, even though it will serialize to the same ABI.
+
+We provide two helpers to convert between these notations:
+* ```fromSerpent```: convert a Serpent notation to the ABI notation
+* ```toSerpent```: the other way around
+
+Example usage:
+```js
+abi.fromSerpent('s')    // [ 'string' ]
+abi.fromSerpent('b')    // [ 'bytes' ]
+abi.fromSerpent('i')    // [ 'int256' ]
+abi.fromSerpent('a')    // [ 'int256[]' ]
+abi.fromSerpent('b8')   // [ 'bytes8' ]
+abi.fromSerpent('b8i')  // [ 'bytes8', 'int256' ]
+
+abi.toSerpent([ 'string' ])            // 's'
+abi.toSerpent([ 'int256' ])            // 'i'
+abi.toSerpent([ 'int256[]' ])          // 'a'
+abi.toSerpent([ 'bytes' ])             // 'b'
+abi.toSerpent([ 'bytes8' ])            // 'b8'
+abi.toSerpent([ 'bytes8', 'int256' ])  // 'b8i'
+```
+
+It is to be used in conjunction with ```rawEncode``` and ```rawDecode```:
+
+```js
+var encoded = abi.rawEncode("balanceOf", abi.fromSerpent("i"), [ "0x0000000000000000000000000000000000000000" ])
+
+var decoded = abi.rawDecode("balanceOf", abi.fromSerpent("i"), abi.fromSerpent("i"), data)
+```
+
 ## Contributing
 
 I am more than happy to receive improvements. Please send me a pull request or reach out on email or twitter.

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,19 @@ function parseTypeArray(type) {
     return parseInt(tmp);
 }
 
+function isHexString(str) {
+  return str.constructor === String &&
+    (str.slice(0,2) === "0x" || str.slice(0,3) === "-0x");
+}
+
+function parseUglyHex(param) {
+  param = new BN(param.replace("0x", ""), 16);
+  if (param.isNeg()) param = param.add((new BN(2)).pow(new BN(256)));
+  param = param.toString(16);
+  if (param.length % 2) param = "0" + param;
+  return new Buffer(param, "hex");
+}
+
 // Encodes a single item (can be dynamic array)
 // @returns: Buffer
 function encodeSingle(type, arg) {
@@ -86,6 +99,7 @@ function encodeSingle(type, arg) {
     var size = parseTypeN(type);
     if ((size % 8) || (size < 8) || (size > 256))
       throw new Error('Invalid int<N> width: ' + size);
+    if (isHexString(arg)) arg = parseUglyHex(arg)
     var num = new BN(arg);
     if (num.bitLength() > size)
       throw new Error('Supplied int exceeds width: ' + size + ' vs ' + num.bitLength());
@@ -313,9 +327,7 @@ ABI.prototype.fromSerpent = function(sig) {
   var ret = [];
   for (var i = 0; i < sig.length; i++) {
     var type = sig[i];
-    if (type === 's') {
-      ret.push('string');
-    } else if (type === 'b') {
+    if (type === 's' || type === 'b') {
       var tmp = 'bytes';
       var j = i + 1;
       while ((j < sig.length) && isNumeric(sig[j])) {
@@ -339,12 +351,10 @@ ABI.prototype.toSerpent = function(types) {
   var ret = [];
   for (var i = 0; i < types.length; i++) {
     var type = types[i];
-    if (type === 'bytes') {
-      ret.push('b');
+    if (type === 'bytes' || type === 'string') {
+      ret.push('s');
     } else if (type.startsWith('bytes')) {
       ret.push('b' + parseTypeN(type));
-    } else if (type === 'string') {
-      ret.push('s');
     } else if (type === 'int256') {
       ret.push('i');
     } else if (type === 'int256[]') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -297,4 +297,63 @@ ABI.prototype.solidityRIPEMD160 = function(types, values) {
   return utils.ripemd160(this.solidityPack(types, values), true);
 };
 
+// Serpent's users are familiar with this encoding
+// - s: string
+// - b: bytes
+// - b<N>: bytes<N>
+// - i: int256
+// - a: int256[]
+
+function isNumeric(c) {
+  // FIXME: is this correct? Seems to work
+  return (c >= '0') && (c <= '9');
+}
+
+ABI.prototype.fromSerpent = function(sig) {
+  var ret = [];
+  for (var i = 0; i < sig.length; i++) {
+    var type = sig[i];
+    if (type === 's') {
+      ret.push('string');
+    } else if (type === 'b') {
+      var tmp = 'bytes';
+      var j = i + 1;
+      while ((j < sig.length) && isNumeric(sig[j])) {
+        tmp += sig[j] - '0';
+        j++;
+      }
+      i = j - 1;
+      ret.push(tmp);
+    } else if (type === 'i') {
+      ret.push('int256');
+    } else if (type === 'a') {
+      ret.push('int256[]');
+    } else {
+      throw new Error('Unsupported or invalid type: ' + type);
+    }
+  }
+  return ret;
+};
+
+ABI.prototype.toSerpent = function(types) {
+  var ret = [];
+  for (var i = 0; i < types.length; i++) {
+    var type = types[i];
+    if (type === 'bytes') {
+      ret.push('b');
+    } else if (type.startsWith('bytes')) {
+      ret.push('b' + parseTypeN(type));
+    } else if (type === 'string') {
+      ret.push('s');
+    } else if (type === 'int256') {
+      ret.push('i');
+    } else if (type === 'int256[]') {
+      ret.push('a');
+    } else {
+      throw new Error('Unsupported or invalid type: ' + type);
+    }
+  }
+  return ret.join('');
+};
+
 module.exports = ABI;

--- a/test/index.js
+++ b/test/index.js
@@ -375,3 +375,41 @@ describe('solidity tight packing ripemd160', function() {
     assert.equal(a.toString('hex'), b.toString('hex'));
   });
 });
+
+describe('converting from serpent types', function() {
+  it('should equal', function() {
+    assert.deepEqual(abi.fromSerpent('s'), [ 'string' ]);
+    assert.deepEqual(abi.fromSerpent('b'), [ 'bytes' ]);
+    assert.deepEqual(abi.fromSerpent('i'), [ 'int256' ]);
+    assert.deepEqual(abi.fromSerpent('a'), [ 'int256[]' ]);
+    assert.deepEqual(abi.fromSerpent('b8'), [ 'bytes8' ]);
+    assert.deepEqual(abi.fromSerpent('b8i'), [ 'bytes8', 'int256' ]);
+    assert.deepEqual(abi.fromSerpent('b32'), [ 'bytes32' ]);
+    assert.deepEqual(abi.fromSerpent('b32i'), [ 'bytes32', 'int256' ]);
+    assert.deepEqual(abi.fromSerpent('sbb8ib8a'), [ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]);
+    assert.throws(function() {
+      abi.fromSerpent('i8');
+    });
+    assert.throws(function() {
+      abi.fromSerpent('x');
+    });
+  });
+});
+
+describe('converting to serpent types', function() {
+  it('should equal', function() {
+    assert.equal(abi.toSerpent([ 'string' ]), 's');
+    assert.equal(abi.toSerpent([ 'int256' ]), 'i');
+    assert.equal(abi.toSerpent([ 'int256[]' ]), 'a');
+    assert.equal(abi.toSerpent([ 'bytes' ]), 'b');
+    assert.equal(abi.toSerpent([ 'bytes8' ]), 'b8');
+    assert.equal(abi.toSerpent([ 'bytes32' ]), 'b32');
+    assert.equal(abi.toSerpent([ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]), 'sbb8ib8a');
+    assert.throws(function() {
+      abi.toSerpent('int8');
+    });
+    assert.throws(function() {
+      abi.toSerpent('bool');
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -378,7 +378,7 @@ describe('solidity tight packing ripemd160', function() {
 
 describe('converting from serpent types', function() {
   it('should equal', function() {
-    assert.deepEqual(abi.fromSerpent('s'), [ 'string' ]);
+    assert.deepEqual(abi.fromSerpent('s'), [ 'bytes' ]);
     assert.deepEqual(abi.fromSerpent('b'), [ 'bytes' ]);
     assert.deepEqual(abi.fromSerpent('i'), [ 'int256' ]);
     assert.deepEqual(abi.fromSerpent('a'), [ 'int256[]' ]);
@@ -386,7 +386,7 @@ describe('converting from serpent types', function() {
     assert.deepEqual(abi.fromSerpent('b8i'), [ 'bytes8', 'int256' ]);
     assert.deepEqual(abi.fromSerpent('b32'), [ 'bytes32' ]);
     assert.deepEqual(abi.fromSerpent('b32i'), [ 'bytes32', 'int256' ]);
-    assert.deepEqual(abi.fromSerpent('sbb8ib8a'), [ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]);
+    assert.deepEqual(abi.fromSerpent('sbb8ib8a'), [ 'bytes', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]);
     assert.throws(function() {
       abi.fromSerpent('i8');
     });
@@ -401,10 +401,10 @@ describe('converting to serpent types', function() {
     assert.equal(abi.toSerpent([ 'string' ]), 's');
     assert.equal(abi.toSerpent([ 'int256' ]), 'i');
     assert.equal(abi.toSerpent([ 'int256[]' ]), 'a');
-    assert.equal(abi.toSerpent([ 'bytes' ]), 'b');
+    assert.equal(abi.toSerpent([ 'bytes' ]), 's');
     assert.equal(abi.toSerpent([ 'bytes8' ]), 'b8');
     assert.equal(abi.toSerpent([ 'bytes32' ]), 'b32');
-    assert.equal(abi.toSerpent([ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]), 'sbb8ib8a');
+    assert.equal(abi.toSerpent([ 'string', 'bytes', 'bytes8', 'int256', 'bytes8', 'int256[]' ]), 'ssb8ib8a');
     assert.throws(function() {
       abi.toSerpent('int8');
     });


### PR DESCRIPTION
I think this makes -abi work for all of the augur code (verifying that tonight).