### PR TITLE
Remove constructor pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ There are two methods of interest, ```rawEncode``` to encode a call (name plus a
 
 Example code:
 ```js
-var ABI = require('ethereumjs-abi')
-var abi = new ABI()
+var abi = require('ethereumjs-abi')
 
 // returns the encoded binary (as a Buffer) data to be sent
 var encoded = abi.rawEncode("balanceOf", [ "address" ], [ "0x0000000000000000000000000000000000000000" ])
@@ -28,15 +27,14 @@ For preparing encoded blocks without the signature, use ```rawEncodeResponse```.
 Planned for the future is supporting the JSON ABI definition:
 
 ```js
-var ABI = require('ethereumjs-abi')
-var abi = new ABI()
+var abi = require('ethereumjs-abi')
 
 // need to have the ABI definition in JSON as per specification
 var tokenAbi = [{"constant":true,"inputs":[{"name":"","type":"address"}],"name":"balanceOf","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":false,"inputs":[{"name":"_to","type":"address"},{"name":"_value","type":"uint256"}],"name":"transfer","outputs":[{"name":"success","type":"bool"}],"type":"function"},{"inputs":[],"type":"constructor"}]
 
-var encoded = ABI.encode(tokenAbi, "balanceOf(uint256 address)", [ "0x0000000000000000000000000000000000000000" ])
+var encoded = abi.encode(tokenAbi, "balanceOf(uint256 address)", [ "0x0000000000000000000000000000000000000000" ])
 
-var decoded = ABI.decode(tokenAbi, "balanceOf(uint256 address)", data)
+var decoded = abi.decode(tokenAbi, "balanceOf(uint256 address)", data)
 ```
 
 #### Solidity *tightly packed* formats
@@ -59,8 +57,7 @@ contract HashTest {
 
 Creating the same hash using this library:
 ```js
-var ABI = require('ethereumjs-abi')
-var abi = new ABI()
+var abi = require('ethereumjs-abi')
 var BN = require('bn.js')
 
 abi.soliditySHA3(

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,12 +1,9 @@
 require('es6-shim');
 const utils = require('ethereumjs-util');
 
-function Common() {
-}
-
 // Convert from short to canonical names
 // FIXME: optimise or make this nicer?
-Common.prototype.elementaryName = function(name) {
+module.exports.elementaryName = function(name) {
   if (name.startsWith('int['))
     return 'int256' + name.slice(4);
   else if (name === 'int')
@@ -26,14 +23,12 @@ Common.prototype.elementaryName = function(name) {
   return name;
 };
 
-Common.prototype.methodID = function(name, types) {
+module.exports.methodID = function(name, types) {
   return this.eventID(name, types).slice(0, 4);
 };
 
-Common.prototype.eventID = function(name, types) {
+module.exports.eventID = function(name, types) {
   // FIXME: use node.js util.format?
   var sig = name + '(' + types.map(this.elementaryName).join(',') + ')';
   return utils.sha3(new Buffer(sig));
 };
-
-module.exports = Common;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,8 @@
 require('es6-shim');
 const utils = require('ethereumjs-util');
 const BN = require('bn.js');
-const Common = require('./common.js');
+const common = require('./common.js');
 const utf8 = require('utf8');
-
-var ABI = function() {
-  this.common = new Common();
-};
 
 // Encode as 256bit two's complement
 function toTwos(num) {
@@ -157,7 +153,7 @@ function isDynamic(type) {
 // Encode a method/event with arguments
 // @types an array of string type names
 // @args  an array of the appropriate values
-ABI.prototype.rawEncode = function(name, types, args) {
+module.exports.rawEncode = function(name, types, args) {
   var output = new Buffer(0);
   var data = new Buffer(0);
 
@@ -170,12 +166,12 @@ ABI.prototype.rawEncode = function(name, types, args) {
   }
 
   if (name !== null)
-    pushOutput(this.common.methodID(name, types));
+    pushOutput(common.methodID(name, types));
 
   const headLength = 32 * types.length;
 
   for (var i in types) {
-    var type = this.common.elementaryName(types[i]);
+    var type = common.elementaryName(types[i]);
     var arg = args[i];
     var cur = encodeSingle(type, arg);
 
@@ -192,29 +188,29 @@ ABI.prototype.rawEncode = function(name, types, args) {
   return output;
 };
 
-ABI.prototype.rawEncodeResponse = function(types, args) {
+module.exports.rawEncodeResponse = function(types, args) {
   return this.rawEncode(null, types, args);
 };
 
-ABI.prototype.encode = function(abiDefinition, request, args) {
+module.exports.encode = function(abiDefinition, request, args) {
   throw new Error('Not implemented');
 };
 
-ABI.prototype.rawDecode = function(name, intypes, outtypes, data) {
+module.exports.rawDecode = function(name, intypes, outtypes, data) {
   var ret = [];
 
   var data = new Buffer(data);
 
   // Validate if signature matches
   if (name !== null) {
-    if (this.common.methodID(name, intypes).toString('hex') !== data.slice(0, 4).toString('hex'))
+    if (common.methodID(name, intypes).toString('hex') !== data.slice(0, 4).toString('hex'))
       throw new Error('Invalid method signature');
     data = data.slice(4);
   }
 
   var offset = 0;
   for (var i in outtypes) {
-    var type = this.common.elementaryName(outtypes[i]);
+    var type = common.elementaryName(outtypes[i]);
     var cur = data.slice(offset, offset + 32);
 
     if (isDynamic(type)) {
@@ -236,17 +232,17 @@ ABI.prototype.rawDecode = function(name, intypes, outtypes, data) {
   return ret;
 };
 
-ABI.prototype.decode = function(abiDefinition, request, data) {
+module.exports.decode = function(abiDefinition, request, data) {
   throw new Error('Not implemented');
 };
 
-ABI.prototype.solidityPack = function(types, values) {
+module.exports.solidityPack = function(types, values) {
   if (types.length !== values.length) {
     throw new Error('Number of types are not matching the values');
   }
   var ret = [];
   for (var i = 0; i < types.length; i++) {
-    var type = this.common.elementaryName(types[i]);
+    var type = common.elementaryName(types[i]);
     var value = values[i];
     if (type === 'bytes') {
       ret.push(value);
@@ -285,16 +281,14 @@ ABI.prototype.solidityPack = function(types, values) {
   return Buffer.concat(ret);
 };
 
-ABI.prototype.soliditySHA3 = function(types, values) {
+module.exports.soliditySHA3 = function(types, values) {
   return utils.sha3(this.solidityPack(types, values));
 };
 
-ABI.prototype.soliditySHA256 = function(types, values) {
+module.exports.soliditySHA256 = function(types, values) {
   return utils.sha256(this.solidityPack(types, values));
 };
 
-ABI.prototype.solidityRIPEMD160 = function(types, values) {
+module.exports.solidityRIPEMD160 = function(types, values) {
   return utils.ripemd160(this.solidityPack(types, values), true);
 };
-
-module.exports = ABI;

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
-var ABI = require('../index.js');
-var abi = new ABI();
+var abi = require('../index.js');
 var BN = require('bn.js');
 
 // Official test vectors from https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI


### PR DESCRIPTION
This removes the use of the constructor pattern since there is no need to instantiate a library of pure functions.  Makes for a much cleaner interface imo.

@axic 